### PR TITLE
解决第7章7.4.4节创建data-policy报错问题

### DIFF
--- a/第7章 Elasticsearch预处理.md
+++ b/第7章 Elasticsearch预处理.md
@@ -192,8 +192,12 @@ PUT my_index_0705
         "type": "keyword"
       }
     }
+  },
+  "aliases": {
+    "index_test_b": {}
   }
 }
+
 ####批量写入数据，和my_index_0704存在相同字段“field_a”。
 POST my_index_0705/_bulk
 {"index":{"_id":1}}

--- a/第8章 Elasticsearch文档.md
+++ b/第8章 Elasticsearch文档.md
@@ -304,7 +304,7 @@ POST _reindex
     "index": "my_index_0803"
   },
   "dest": {
-    "index": "my_index_0908",
+    "index": "my_index_0808",
     "version_type": "external"
   },
   "script": {
@@ -314,11 +314,11 @@ POST _reindex
 }
 
 ####批量写入数据
-POST my_index_0909/_bulk
+POST my_index_0809/_bulk
 {"index":{"_id":1}}
 {"title":" foo bar "}
 ####执行检索操作
-GET my_index_0909/_search
+GET my_index_0809/_search
 ####定义预处理管道
 PUT _ingest/pipeline/my-trim-pipeline
 {
@@ -335,15 +335,15 @@ PUT _ingest/pipeline/my-trim-pipeline
 POST _reindex
 {
   "source": {
-    "index": "my_index_0909"
+    "index": "my_index_0809"
   },
   "dest": {
-    "index": "my_index_0910",
+    "index": "my_index_0810",
     "pipeline": "my-trim-pipeline"
   }
 }
 ####获取迁移后的检索结果
-GET my_index_0910/_search
+GET my_index_0810/_search
 ```
 
 ### 8.5.4 不同集群索引之间迁移数据


### PR DESCRIPTION
错误：由于没有`index_test_b`索引，报404 Not Found错误，无法找到该索引
修复方式：在my_index_0705的索引创建时，使用index_test_b作为别名。